### PR TITLE
Add conditional verbosity helping debugging

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,6 +49,10 @@ function run_npm() {
 
   if [ "${PIPESTATUS[*]}" != "0 0" ]; then
     echo " !     Failed to $command dependencies with npm"
+    if [ ! -z $BUILDPACK_RETRY_VERBOSE ]; then
+      echo " ! Relaunching the command in verbose mode to help debugging"
+      run_npm "--verbose $command"
+    fi
     exit 1
   fi
 }


### PR DESCRIPTION
Sometimes, often, npm shitstorm happens and deployment fails. That's the moment you want npm to be more verbose, helping you finding the culprit.

I made these little changes so that:
- the VERBOSE environment variable makes npm always verbose if set
- the BUILDPACK_RETRY_VERBOSE is more subtle: it run npm as usual, as long as npm is happy. If npm failed, it relaunch npm in verbose mode

Set environment variables with the usual `heroku config:set KEY=value` command.
These two flags can be cumulated with no worries because `npm --verbose --verbose`works fine.

Hope you'll like it.
