### PR TITLE
prune devDependencies after build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -91,7 +91,7 @@ fi
 
   status "Installing dependencies"
   # Make npm output to STDOUT instead of its default STDERR
-  npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
+  npm install --userconfig $build_dir/.npmrc 2>&1 | indent
 )
 
 # Persist goodies like node-version in the slug
@@ -153,6 +153,10 @@ echo "export PATH=\"\$HOME/vendor/node/bin:\$HOME/bin:\$HOME/node_modules/.bin:\
     npm install grunt
     echo "-----> Found Gruntfile, running grunt heroku:$NODE_ENV task"
     $build_dir/node_modules/.bin/grunt heroku:$NODE_ENV
+
+    status "Pruning dev dependencies"
+    npm prune --production 2>&1 | indent
+
   else
     echo "-----> No Gruntfile (grunt.js, Gruntfile.js, Gruntfile.coffee) found"
   fi


### PR DESCRIPTION
This fix #5 . <code>npm prune --production </code> is working again on Heroku. Now devDependencies are installed and when grunt process ends this dependencies are removed using <code>npm prune --production</code>.
