### PR TITLE
unset GIT_DIR to allow of use of commit SHAs in bower.json

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,6 +11,9 @@ env_dir=$3
 
 bp_dir=$(cd $(dirname $0); cd ..; pwd)
 
+# Fix leak
+unset GIT_DIR
+
 # Load some convenience functions like status(), echo(), and indent()
 source $bp_dir/bin/common.sh
 


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-nodejs/issues/99.