### PR TITLE
Install node condition

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,8 +45,8 @@ else
 fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
-if [ -d $build_dir/vendor/node ]; then
-  status "Using detected Node installation"
+if test -d $build_dir/vendor/node; then
+  status "Found existing Node installation"
 else
   status "Downloading and installing node"
   node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"

--- a/bin/compile
+++ b/bin/compile
@@ -45,13 +45,18 @@ else
 fi
 
 # Download node from Heroku's S3 mirror of nodejs.org/dist
-status "Downloading and installing node"
-node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
-curl $node_url -s -o - | tar xzf - -C $build_dir
+if [ -d $build_dir/vendor/node ]; then
+  status "Using detected Node installation"
+else
+  status "Downloading and installing node"
+  node_url="http://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
+  curl $node_url -s -o - | tar xzf - -C $build_dir
 
-# Move node (and npm) into ./vendor and make them executable
-mkdir -p $build_dir/vendor
-mv $build_dir/node-v$node_version-linux-x64 $build_dir/vendor/node
+  # Move node (and npm) into ./vendor and make them executable
+  mkdir -p $build_dir/vendor
+  mv $build_dir/node-v$node_version-linux-x64 $build_dir/vendor/node
+fi
+
 chmod +x $build_dir/vendor/node/bin/*
 PATH=$PATH:$build_dir/vendor/node/bin
 

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ else
   status "Resolved node version: $node_version"
 fi
 
-# If Node is already installed, use that installtion
+# If Node is already installed, use that installation
 # Otherwise download node from Heroku's S3 mirror of nodejs.org/dist
 if test -d $build_dir/vendor/node; then
   status "Found existing Node installation"

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,8 @@ else
   status "Resolved node version: $node_version"
 fi
 
-# Download node from Heroku's S3 mirror of nodejs.org/dist
+# If Node is already installed, use that installtion
+# Otherwise download node from Heroku's S3 mirror of nodejs.org/dist
 if test -d $build_dir/vendor/node; then
   status "Found existing Node installation"
 else


### PR DESCRIPTION
Added node installation condition to first check if Node is already installed in `$build_dir/vendor/node`. If it is, then use that installation. Otherwise, download and install Node as normal.

This helps circumvent problems when building an app that already has Node installed in `$build_dir/vendor/node` from a previous build with this buildpack.
