### PR TITLE
Added bower support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Here's an overview of what this buildpack does:
 - Runs `npm rebuild` if `node_modules` is checked into version control.
 - Always runs `npm install` to ensure [npm script hooks](https://npmjs.org/doc/misc/npm-scripts.html) are executed.
 - Always runs `npm prune` after restoring cached modules to ensure cleanup of unused dependencies.
+- Runs `bower install` if bower.json file is found (will also install bower locally so no need adding bower to your project dependencies).
 - Runs `grunt` if a Gruntfile (`Gruntfile.js`, `Gruntfile.coffee`or `grunt.js`) is found.
 
 For more technical details, see the [heavily-commented compile script](https://github.com/mbuchetics/heroku-buildpack-nodejs-grunt/blob/master/bin/compile).

--- a/bin/compile
+++ b/bin/compile
@@ -80,10 +80,10 @@ fi
 
 # Handle npm's new cert bug
 # http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
-if [ ! -f "$build_dir/.npmrc" ]; then
-  status "Writing a custom .npmrc to circumvent npm bugs"
-  echo "ca=" > "$build_dir/.npmrc"
-fi
+#if [ ! -f "$build_dir/.npmrc" ]; then
+#  status "Writing a custom .npmrc to circumvent npm bugs"
+#  echo "ca=" > "$build_dir/.npmrc"
+#fi
 
 # Scope config var availability only to `npm install`
 (

--- a/bin/compile
+++ b/bin/compile
@@ -146,6 +146,15 @@ status "Building runtime environment"
 mkdir -p $build_dir/.profile.d
 echo "export PATH=\"\$HOME/vendor/node/bin:\$HOME/bin:\$HOME/node_modules/.bin:\$PATH\";" > $build_dir/.profile.d/nodejs.sh
 
+# Check and run Bower
+(
+  if [ -f $build_dir/bower.json ]; then
+    status "Installing bower components"
+    npm install bower
+    echo "-----> Found bower.json, running bower install"
+    $build_dir/node_modules/.bin/bower install
+  fi
+)
 # Check and run Grunt
 (
   if [ -f $build_dir/grunt.js ] || [ -f $build_dir/Gruntfile.js ] || [ -f $build_dir/gruntfile.js ] || [ -f $build_dir/Gruntfile.coffee ]; then


### PR DESCRIPTION
Will run `bower install` before running the grunt tasks (if bower.json file was found) as we often need our client js components for the grunt tasks (concat, minify & more). 
Will also run `npm install bower` as we don't need to add bower to our project dependencies.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mbuchetics/heroku-buildpack-nodejs-grunt/27)

<!-- Reviewable:end -->
