### PR TITLE
Update README.md to fix deprecated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create a new app with this buildpack:
 
 Or add this buildpack to your current app:
 
-    heroku config:add BUILDPACK_URL=https://github.com/mbuchetics/heroku-buildpack-nodejs-grunt.git
+    heroku buildpacks:set https://github.com/mbuchetics/heroku-buildpack-nodejs-grunt.git
 
 Set the `NODE_ENV` environment variable (e.g. `development` or `production`):
 


### PR DESCRIPTION
The instructions in the README.md for adding a buildpack to an existing app have been deprecated. The new command for setting the buildpack is to use "heroku buildpacks:set". 

**Before:**
![screen shot 2015-11-04 at 5 33 35 pm](https://github-cloud.s3.amazonaws.com/assets%2F13375241%2F10957572%2F74e11f60-831a-11e5-9066-29e58135c969.png)

**After:**
![screen shot 2015-11-04 at 5 53 08 pm](https://github-cloud.s3.amazonaws.com/assets%2F13375241%2F10957829%2Ff7b795b6-831c-11e5-99a4-c879e40c302a.png)


Here's a screenshot from the documentation:

![screen shot 2015-11-04 at 5 45 32 pm](https://github-cloud.s3.amazonaws.com/assets%2F13375241%2F10957732%2Fdfa23b8a-831b-11e5-96ba-0907f50570f0.png)

https://devcenter.heroku.com/articles/buildpacks#using-a-custom-buildpack

Thanks,
Michael Kim